### PR TITLE
Add list-authorized-keys script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ include standard.mk
 
 .PHONY: local
 local:
-	$(CONTAINER_ENGINE) run --rm --publish 2222:2222 --interactive --tty $(IMAGE_URI_LATEST) bash
+	$(CONTAINER_ENGINE) run --rm --publish 2222:2222 --interactive --tty --volume $(HOME)/.ssh/authorized_keys:/var/run/authorized_keys.d/authorized_keys --name sre-sshd $(IMAGE_URI_LATEST)

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -15,6 +15,9 @@ RUN yum install -y vim-enhanced initscripts openssh-server openssh-clients
 ADD pam_sshd /etc/pam.d/sshd
 RUN chmod 644 /etc/pam.d/sshd && chown root.root /etc/pam.d/sshd
 
+ADD list-authorized-keys /etc/ssh/list-authorized-keys
+RUN chmod 755 /etc/ssh/list-authorized-keys
+
 RUN useradd sre-user && \
     sed -i '/sre-user/d' /etc/passwd
 RUN rm -rf /home/sre-user
@@ -30,10 +33,9 @@ RUN chgrp -R 0 /opt && \
 
 RUN mkdir /opt/ssh_files && chmod 775 /opt/ssh_files
 ADD sshd_config /opt/ssh_files
-ADD authorized_keys /opt/ssh_files
 ADD bashrc /opt/ssh_files
 ADD bash_profile /opt/ssh_files
-RUN chmod 664 /opt/ssh_files/sshd_config /opt/ssh_files/authorized_keys
+RUN chmod 664 /opt/ssh_files/sshd_config
 
 ADD start-sshd.sh /opt
 ADD sshd-keygen /opt

--- a/container/list-authorized-keys
+++ b/container/list-authorized-keys
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+DIR=/var/run/authorized_keys.d
+
+if [ -d "$DIR" ]
+then
+  find $DIR -type f -print0 | xargs -0 cat | sort | uniq
+fi

--- a/container/sshd_config
+++ b/container/sshd_config
@@ -45,12 +45,12 @@ LogLevel DEBUG
 
 # The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
 # but this is overridden so installations will only check .ssh/authorized_keys
-AuthorizedKeysFile	.ssh/authorized_keys
+AuthorizedKeysFile none
 
 #AuthorizedPrincipalsFile none
 
-#AuthorizedKeysCommand none
-#AuthorizedKeysCommandUser nobody
+AuthorizedKeysCommand /etc/ssh/list-authorized-keys
+AuthorizedKeysCommandUser sre-user
 
 # For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
 #HostbasedAuthentication no
@@ -63,7 +63,7 @@ AuthorizedKeysFile	.ssh/authorized_keys
 # To disable tunneled clear text passwords, change to no here!
 #PasswordAuthentication yes
 #PermitEmptyPasswords no
-PasswordAuthentication yes
+PasswordAuthentication no
 
 # Change to no to disable s/key passwords
 #ChallengeResponseAuthentication yes

--- a/container/start-sshd.sh
+++ b/container/start-sshd.sh
@@ -23,10 +23,6 @@ chmod 700 /home/sre-user/.ssh
 cp /opt/ssh_files/bashrc /home/sre-user/.bashrc
 cp /opt/ssh_files/bash_profile /home/sre-user/.bash_profile
 
-# setup authorized_keys file
-cp /opt/ssh_files/authorized_keys /home/sre-user/.ssh/authorized_keys
-chmod 600 /home/sre-user/.ssh/authorized_keys
-
 # setup SSHD
 mkdir /opt/sshd
 cp /opt/ssh_files/sshd_config /opt/sshd

--- a/container/start-sshd.sh
+++ b/container/start-sshd.sh
@@ -13,7 +13,7 @@ trap "handle_signal" SIGINT SIGTERM SIGHUP
 USER_ID="$(id -u)"
 GROUP_ID="$(id -g)"
 #false at the end for non interactive user
-echo "sre-user::${USER_ID}:${GROUP_ID}:SRE USER:/home/sre-user:false" >> /etc/passwd
+echo "sre-user::${USER_ID}:${GROUP_ID}:SRE USER:/home/sre-user:/bin/false" >> /etc/passwd
 
 # setup sre-user home dir
 mkdir /home/sre-user


### PR DESCRIPTION
This will serve as the SSH server's [AuthorizedKeysCommand](https://man.openbsd.org/sshd_config#AuthorizedKeysCommand).

Finds all regular files under `/opt/ssh_files/authorized_keys.d` and outputs all unique keys.

The intention is to mount ConfigMaps containing authorized keys for various teams under this directory.