### PR TITLE
Use "sleepysh" as sre-user's login shell

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -18,6 +18,9 @@ RUN chmod 644 /etc/pam.d/sshd && chown root.root /etc/pam.d/sshd
 ADD list-authorized-keys /etc/ssh/list-authorized-keys
 RUN chmod 755 /etc/ssh/list-authorized-keys
 
+ADD sleepysh /bin/sleepysh
+RUN chmod 755 /bin/sleepysh
+
 RUN useradd sre-user && \
     sed -i '/sre-user/d' /etc/passwd
 RUN rm -rf /home/sre-user

--- a/container/sleepysh
+++ b/container/sleepysh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo Connected. Press Ctrl-C to exit.
+sleep infinity

--- a/container/start-sshd.sh
+++ b/container/start-sshd.sh
@@ -12,8 +12,8 @@ trap "handle_signal" SIGINT SIGTERM SIGHUP
 # add sre-user to /etc/passwd
 USER_ID="$(id -u)"
 GROUP_ID="$(id -g)"
-#false at the end for non interactive user
-echo "sre-user::${USER_ID}:${GROUP_ID}:SRE USER:/home/sre-user:/bin/false" >> /etc/passwd
+# sleepysh is non-interactive but never exits
+echo "sre-user::${USER_ID}:${GROUP_ID}:SRE USER:/home/sre-user:/bin/sleepysh" >> /etc/passwd
 
 # setup sre-user home dir
 mkdir /home/sre-user


### PR DESCRIPTION
`sleepysh` just runs `sleep infinite`, giving a non-interactive but also non-terminating shell session.