### PR TITLE
Use centos8 as base image

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7
+FROM centos:centos8
 
 # creature comforts
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
To gain a newer openssh package with a fix for
https://bugzilla.mindrot.org/show_bug.cgi?id=2655

This caused `list-authorized-keys` to sometimes die by `SIGPIPE`, and `sshd` would reject its output.  The fault was with `sshd`; it now consumes the entire output regardless of how early it finds a matching key.