### PR TITLE
sshd_config: Enable client alive messages

### DIFF
--- a/container/sshd_config
+++ b/container/sshd_config
@@ -110,8 +110,8 @@ X11Forwarding yes
 #UsePrivilegeSeparation sandbox
 #PermitUserEnvironment no
 #Compression delayed
-#ClientAliveInterval 0
-#ClientAliveCountMax 3
+ClientAliveInterval 5m
+ClientAliveCountMax 3
 #ShowPatchLevel no
 #UseDNS yes
 PidFile /tmp/sshd.pid


### PR DESCRIPTION
Send periodic client alive messages to keep the ELB's idle timeout from closing the SSH connection.